### PR TITLE
Make the template plugin compatible with python-deployer

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 description = ""
 authors = ["Arcalot"]
 license = "Apache-2.0+GPL-2.0-only"
-
+classifiers = ["Arcaflow :: Python Deployer :: Runnable"]
 packages = [
    { include="arcaflow_plugin_template_python.py", from="./arcaflow_plugin_template_python"  },
 ]


### PR DESCRIPTION
This change in the pyproject.toml will mark the plugin as runnable by the arcaflow-python-deployer adding to the pyproject.toml the capability `Arcaflow :: Python Deployer :: Runnable`.
The deployer will run a pip show --verbose <module_name> and, if the flag has been added in the capabilities field, will be printed to stdout and captured by the deployer that will  run the plugin. If a plugin is not marked as `Runnable` won't be run by the deployer (unless the security checks are not explicitly overridden in the deployer config).